### PR TITLE
feat: add header button

### DIFF
--- a/resources/js/quill.js
+++ b/resources/js/quill.js
@@ -11,9 +11,11 @@ import {
 } from './utils.js';
 import ImageUploader from './custom-handlers/image-uploader';
 import InsertBr from './custom-handlers/insert-br';
+import Header from "quill/formats/header.js";
 
 Quill.register('modules/imageUploader', ImageUploader);
 Quill.register('modules/insertBr', InsertBr);
+Quill.register('formats/header', Header);
 
 window.Quill = Quill;
 

--- a/resources/views/partials/toolbar.blade.php
+++ b/resources/views/partials/toolbar.blade.php
@@ -242,4 +242,12 @@
             @endif
         </x-filament-quill::toolbar-group>
     @endforeach
+
+    @if ($hasToolbarButton(ToolbarButton::Header))
+        <select class="ql-header" title="{{ __('filament-quill::quill.toolbar.header') }}">
+            @foreach ($headers as $header)
+                <option value="{{ $header }}" data-label="{{ $header }}" @selected($header === $defaultHeaderSize)></option>
+            @endforeach
+        </select>
+    @endif
 </div>

--- a/resources/views/quill-editor.blade.php
+++ b/resources/views/quill-editor.blade.php
@@ -6,9 +6,11 @@
     $id = $getId();
     $statePath = $getStatePath();
     $isDisabled = $isDisabled();
+    $headers = $getHeaders();
     $fonts = $getFonts();
     $fontSizes = $getFontSizes();
     $defaultFontSize = $getDefaultFontSize();
+    $defaultHeaderSize = $getDefaultHeaderSize();
     $textChangeHandler = $getOnTextChangeHandler();
     $onInitCallback = $getOnInitCallback();
     $hasHistory = $hasToolbarButton([\Rawilk\FilamentQuill\Enums\ToolbarButton::Undo, \Rawilk\FilamentQuill\Enums\ToolbarButton::Redo]);

--- a/src/Concerns/HasQuillToolbar.php
+++ b/src/Concerns/HasQuillToolbar.php
@@ -37,7 +37,20 @@ trait HasQuillToolbar
         '40px',
     ];
 
+    protected array|Closure|null $headers = [
+        '1', '2', '3', '4', '5', '6', false,
+    ];
+
+    protected string|bool|Closure|null $defaultHeaderSize = false;
+
     protected string|Closure|null $defaultFontSize = '14px';
+
+    public function setHeaders(array|Closure $headers = []): static
+    {
+        $this->headers = $headers;
+
+        return $this;
+    }
 
     public function useFonts(array|Closure|null $fonts = null): static
     {
@@ -84,6 +97,16 @@ trait HasQuillToolbar
     public function getFonts(): ?array
     {
         return $this->evaluate($this->fonts);
+    }
+
+    public function getHeaders(): ?array
+    {
+        return $this->evaluate($this->headers);
+    }
+
+    public function getDefaultHeaderSize(): bool|string
+    {
+        return $this->evaluate($this->defaultHeaderSize);
     }
 
     public function getTextColors(): ?array

--- a/src/Enums/ToolbarButton.php
+++ b/src/Enums/ToolbarButton.php
@@ -26,4 +26,5 @@ enum ToolbarButton: string
     case Undo = 'undo';
     case Redo = 'redo';
     case ClearFormat = 'clean';
+    case Header = 'header';
 }

--- a/src/Filament/Forms/Components/QuillEditor.php
+++ b/src/Filament/Forms/Components/QuillEditor.php
@@ -60,6 +60,7 @@ class QuillEditor extends Field implements CanBeLengthConstrained, HasFileAttach
         ToolbarButton::Undo,
         ToolbarButton::Redo,
         ToolbarButton::ClearFormat,
+        ToolbarButton::Header,
     ];
 
     public function loadStyles(?bool $condition = true): static

--- a/tests/Feature/QuillTest.php
+++ b/tests/Feature/QuillTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Illuminate\Contracts\View\View;
+use Rawilk\FilamentQuill\Enums\ToolbarButton;
 use Rawilk\FilamentQuill\Filament\Forms\Components\QuillEditor;
 use Rawilk\FilamentQuill\Tests\Fixtures\Filament\Resources\PageResource\Pages\CreatePage;
 use Rawilk\FilamentQuill\Tests\Fixtures\Filament\Resources\PageResource\Pages\EditPage;
@@ -53,6 +54,39 @@ test('content can be updated', function () {
     expect($page->refresh())
         ->title->toBe($newData->title)
         ->content->toBe($newData->content);
+});
+
+test('can see header button and has default headers set', function () {
+    $livewire = livewire(TestComponentWithForm::class);
+
+    $headersArray = ['1', '2', '3', '4', '5', '6', false];
+
+    $quillEditor = $livewire->content()->form->getComponents()[1];
+
+    expect($quillEditor->getToolbarButtons())
+        ->toContain((ToolbarButton::Header)->value)
+        ->and($quillEditor->getHeaders())
+        ->toEqual($headersArray);
+
+    $testArray = ['1', '2', '3'];
+
+    $quillEditor->setHeaders($testArray);
+
+    expect($quillEditor->getHeaders())
+        ->toEqual($testArray);
+});
+
+test('can set available headers in quill editor', function () {
+    $livewire = livewire(TestComponentWithForm::class);
+
+    $quillEditor = $livewire->content()->form->getComponents()[1];
+
+    $testArray = ['1', '2', '3'];
+
+    $quillEditor->setHeaders($testArray);
+
+    expect($quillEditor->getHeaders())
+        ->toEqual($testArray);
 });
 
 class TestComponentWithForm extends LivewireFixture


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes I did. Related Issue: https://github.com/rawilk/filament-quill/issues/34

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes, I have Included test to check new functionality

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This PR adds new Headers dropdown button to allow users to set headers in edited text:

<img width="684" alt="Screenshot 2024-05-03 at 20 25 26" src="https://github.com/rawilk/filament-quill/assets/43916409/2d7f9d1d-c3bb-4c26-8160-d20f8eb1d01f">

This PR introduces new enum `ToolbarButton::Header` that can be used inside `toolbarButtons([])` method to add new button to toolbar.

We can also control available header sizes by passing array of header sizes to new `setHeaders()` method.

```php
QuillEditor::make('value')
    ->toolbarButtons([
        ToolbarButton::Header,
    ])
    ->setHeaders(['1', '2', false]),
```
will produce following:
<img width="690" alt="Screenshot 2024-05-03 at 20 19 32" src="https://github.com/rawilk/filament-quill/assets/43916409/29ae0ac6-0ea0-4037-a4b9-404126fe09a2">

The `false` in array stands for Normal text.

5️⃣ Thanks for contributing! 🙌
