### PR TITLE
Fix $entangle method call typo

### DIFF
--- a/resources/views/quill-editor.blade.php
+++ b/resources/views/quill-editor.blade.php
@@ -67,7 +67,7 @@
                     @endif
                     ax-load-src="{{ FilamentAsset::getAlpineComponentSrc('quill', package: FilamentQuillServiceProvider::PACKAGE_ID) }}"
                     x-data="quill({
-                        state: $wire.{{ $applyStateBindingModifiers("entangle('{$statePath}')", isOptimisticallyLive: false) }},
+                        state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
                         statePath: '{{ $statePath }}',
                         placeholder: @js($getPlaceholder()),
                         options: @js($getQuillOptions()),


### PR DESCRIPTION
A bug was discovered and mentioned in discussion #58 that there is a JavaScript error for an unexpected token. This is because the method call to Livewire's `$entangle` helper is missing the `$` in front of it, so there is a syntax error. This PR fixes the typo, which should resolve the syntax errors in the console.
