### PR TITLE
fix: assets are not loading in editor since Filament updated async-alpine to v2.0

### DIFF
--- a/resources/views/quill-editor.blade.php
+++ b/resources/views/quill-editor.blade.php
@@ -61,11 +61,11 @@
             >
                 <div
                     @if ($hasSpaMode)
-                        ax-load="visible"
+                        x-load="visible"
                     @else
-                        ax-load
+                        x-load
                     @endif
-                    ax-load-src="{{ FilamentAsset::getAlpineComponentSrc('quill', package: FilamentQuillServiceProvider::PACKAGE_ID) }}"
+                    x-load-src="{{ FilamentAsset::getAlpineComponentSrc('quill', package: FilamentQuillServiceProvider::PACKAGE_ID) }}"
                     x-data="quill({
                         state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
                         statePath: '{{ $statePath }}',


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

5️⃣ Thanks for contributing! 🙌

In this pr I update calls to async-alpine since it was updated in filament to version 2.0 making this package not load correctly in recent versions of Filament.

Please see issue for description: 
http://github.com/rawilk/filament-quill/issues/107